### PR TITLE
Removed references to missing story board

### DIFF
--- a/BMDropMenu/Info.plist
+++ b/BMDropMenu/Info.plist
@@ -22,8 +22,6 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Hi,
there was small issue with plist. It had a reference to story board. as a result -- test application was crashing right after start. 

I removed this reference.

Thanks,
Alex